### PR TITLE
Use "is defined" to avoid crash when no certs

### DIFF
--- a/tasks/pre_tasks.yml
+++ b/tasks/pre_tasks.yml
@@ -15,7 +15,7 @@
   no_log: true
   with_items:
     - "{{ certificates }}"
-  when: certificates 
+  when: certificates is defined
     
 - name: copy over custom 403
   copy:


### PR DESCRIPTION
The role appears to crash when run with an inventory containing no `certificates` var. Workaround was to use an empty array (`certificates: []`).

I see you previously had `when: certificates is defined` but this was removed in the last commit.